### PR TITLE
Initial Play Iteratees API for secondary indexes lookup

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,8 +36,8 @@ libraryDependencies ++= {
     "ch.qos.logback"          %   "logback-classic"        % "1.0.11"       % "provided",
     "com.typesafe.akka"       %%  "akka-testkit"           % akkaVersion    % "test",
     "io.spray"                %   "spray-testkit"          % sprayVersion   % "test",
-    "org.specs2"              %%  "specs2"                 % "1.14"         % "test"
-  )
+    "org.specs2"              %%  "specs2"                 % "1.14"         % "test",
+    "play"                    %%  "play-iteratees"         % "2.1.1")
 }
 
 initialCommands in console += {

--- a/src/main/scala/com/scalapenos/riak/RiakBucket.scala
+++ b/src/main/scala/com/scalapenos/riak/RiakBucket.scala
@@ -19,6 +19,7 @@ package com.scalapenos.riak
 
 trait RiakBucket {
   import scala.concurrent.{ExecutionContext, Future}
+  import play.api.libs.iteratee.Iteratee
   import internal._
 
   /**
@@ -32,6 +33,10 @@ trait RiakBucket {
   def fetch(index: String, value: String): Future[List[RiakValue]] = fetch(RiakIndex(index, value))
   def fetch(index: String, value: Int): Future[List[RiakValue]] = fetch(RiakIndex(index, value))
   def fetch(index: RiakIndex): Future[List[RiakValue]]
+
+  def stream[A](index: String, value: String, consumer: Iteratee[RiakValue, A]): Future[Iteratee[RiakValue, A]] = stream(RiakIndex(index, value), consumer)
+  def stream[A](index: String, value: Int, consumer: Iteratee[RiakValue, A]): Future[Iteratee[RiakValue, A]] =  stream(RiakIndex(index, value), consumer)
+  def stream[A](index: RiakIndex, consumer: Iteratee[RiakValue, A]): Future[Iteratee[RiakValue, A]]
 
   def fetch(index: String, start: String, end: String): Future[List[RiakValue]] = fetch(RiakIndexRange(index, start, end))
   def fetch(index: String, start: Int, end: Int): Future[List[RiakValue]] = fetch(RiakIndexRange(index, start, end))

--- a/src/main/scala/com/scalapenos/riak/internal/RiakHttpClient.scala
+++ b/src/main/scala/com/scalapenos/riak/internal/RiakHttpClient.scala
@@ -33,9 +33,13 @@ private[riak] final class RiakHttpClient(helper: RiakHttpClientHelper, server: R
 // ============================================================================
 
 private[riak] final class RiakHttpBucket(helper: RiakHttpClientHelper, server: RiakServerInfo, bucket: String, val resolver: RiakConflictsResolver) extends RiakBucket {
+  import play.api.libs.iteratee.Iteratee
+
   def fetch(key: String) = helper.fetch(server, bucket, key, resolver)
   def fetch(index: RiakIndex) = helper.fetch(server, bucket, index, resolver)
   def fetch(indexRange: RiakIndexRange) = helper.fetch(server, bucket, indexRange, resolver)
+
+  def stream[A](index: RiakIndex, consumer: Iteratee[RiakValue, A]) = helper.stream(server, bucket, index, resolver, consumer)
 
   def store(key: String, value: RiakValue) = helper.store(server, bucket, key, value, resolver)
   def storeAndFetch(key: String, value: RiakValue) = helper.storeAndFetch(server, bucket, key, value, resolver)


### PR DESCRIPTION
Here's an initial implementation at a Play Iteratees API for the secondary indexes lookup. It doesn't yet resolve the loading of the list of keys into memory, but it does make the fetching of the actual values work with an iteratee.

There's a basic that confirms that the happy flow works, but more extensive tests are needed to confirm that the potential ways of failure are handled correctly.

A flaw of this implementation is that if one of the key lookups returns a `None`, the enumerator is closed, instead of continuing with trying the next key (which would be more like it works for the regular `fetch` methods.
