### PR TITLE
New fetchWithSiblings RiakBucket operation

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -16,6 +16,12 @@ riak {
     # set to UUID.randomUUID().toString and will only be set once per instance
     # of the client (i.e. per ActorSystem)
     add-client-id-header = no
+
+    # Should the client ignore deleted values (tombstones) when fetching Riak objects
+    # with multiple values (siblings).
+    #
+    # Riak server designates values as tombstones by adding an optional 'X-Riak-Deleted' header.
+    ignore-tombstones = yes
 }
 
 spray.can.client {

--- a/src/main/scala/com/scalapenos/riak/RiakBucket.scala
+++ b/src/main/scala/com/scalapenos/riak/RiakBucket.scala
@@ -29,6 +29,7 @@ trait RiakBucket {
   def resolver: RiakConflictsResolver
 
   def fetch(key: String): Future[Option[RiakValue]]
+  def fetchWithSiblings(key: String): Future[Option[Set[RiakValue]]]
 
   def fetch(index: String, value: String): Future[List[RiakValue]] = fetch(RiakIndex(index, value))
   def fetch(index: String, value: Int): Future[List[RiakValue]] = fetch(RiakIndex(index, value))

--- a/src/main/scala/com/scalapenos/riak/internal/RiakClientSettings.scala
+++ b/src/main/scala/com/scalapenos/riak/internal/RiakClientSettings.scala
@@ -33,6 +33,16 @@ private[riak] class RiakClientSettings(config: Config) {
    */
   final val AddClientIdHeader: Boolean = config.getBoolean("riak.add-client-id-header")
 
+  /**
+   * Setting for controlling whether the Riak client should ignore deleted values ('tombstones')
+   * when fetching objects with multiple values ('siblings').
+   *
+   * Riak server designates values as tombstones by adding an optional 'X-Riak-Deleted' header.
+   *
+   * This value defaults to true.
+   */
+  final val IgnoreTombstones: Boolean = config.getBoolean("riak.ignore-tombstones")
+
   // TODO: add setting for silently ignoring indexes on backends that don't allow them. The alternative is failing/throwing exceptions
 
 }

--- a/src/main/scala/com/scalapenos/riak/internal/RiakHttpBucket.scala
+++ b/src/main/scala/com/scalapenos/riak/internal/RiakHttpBucket.scala
@@ -19,6 +19,7 @@ package internal
 
 private[riak] sealed class RiakHttpBucket(helper: RiakHttpClientHelper, server: RiakServerInfo, val name: String, val resolver: RiakConflictsResolver) extends RiakBucket {
   def fetch(key: String) = helper.fetch(server, name, key, resolver)
+  def fetchWithSiblings(key: String) = helper.fetchWithSiblings(server, name, key, resolver)
   def fetch(index: RiakIndex) = helper.fetch(server, name, index, resolver)
   def fetch(indexRange: RiakIndexRange) = helper.fetch(server, name, indexRange, resolver)
 

--- a/src/main/scala/com/scalapenos/riak/internal/RiakHttpClientHelper.scala
+++ b/src/main/scala/com/scalapenos/riak/internal/RiakHttpClientHelper.scala
@@ -293,7 +293,7 @@ private[riak] class RiakHttpClientHelper(system: ActorSystem) extends RiakUriSup
     val vclockHeader = response.headers.find(_.is(`X-Riak-Vclock`.toLowerCase)).toList
 
     response.entity.as[MultipartContent] match {
-      case Left(error) ⇒ throw new ConflictResolutionFailed(error.toString)
+      case Left(error) ⇒ throw new BucketOperationFailed(s"Failed to parse server response as multipart content due to: '$error'" )
       case Right(multipartContent) ⇒
         // TODO: make ignoring deleted values optional
 

--- a/src/main/scala/com/scalapenos/riak/internal/RiakHttpClientHelper.scala
+++ b/src/main/scala/com/scalapenos/riak/internal/RiakHttpClientHelper.scala
@@ -292,7 +292,7 @@ private[riak] class RiakHttpClientHelper(system: ActorSystem) extends RiakUriSup
     val vclockHeader = response.headers.find(_.is(`X-Riak-Vclock`.toLowerCase)).toList
 
     response.entity.as[MultipartContent] match {
-      case Left(error) ⇒ throw new BucketOperationFailed(s"Failed to parse server response as multipart content due to: '$error'" )
+      case Left(error) ⇒ throw new BucketOperationFailed(s"Failed to parse the server response as multipart content due to: '$error'")
       case Right(multipartContent) ⇒
         // TODO: make ignoring deleted values optional
 

--- a/src/main/scala/com/scalapenos/riak/internal/RiakHttpClientHelper.scala
+++ b/src/main/scala/com/scalapenos/riak/internal/RiakHttpClientHelper.scala
@@ -87,7 +87,6 @@ private[riak] class RiakHttpClientHelper(system: ActorSystem) extends RiakUriSup
         case NotFound        ⇒ successful(None)
         case MultipleChoices ⇒ successful(Some(toRiakSiblingValues(response)))
         case other           ⇒ throw new BucketOperationFailed(s"Fetch for key '$key' in bucket '$bucket' produced an unexpected response code '$other'.")
-        // TODO: case NotModified => successful(None)
       }
     }
   }

--- a/src/main/scala/com/scalapenos/riak/internal/RiakHttpClientHelper.scala
+++ b/src/main/scala/com/scalapenos/riak/internal/RiakHttpClientHelper.scala
@@ -264,7 +264,7 @@ private[riak] class RiakHttpClientHelper(system: ActorSystem) extends RiakUriSup
 
     response.entity.as[MultipartContent] match {
       case Left(error) ⇒ throw new ConflictResolutionFailed(error.toString)
-      case Right(multipartContent) ⇒ {
+      case Right(multipartContent) ⇒
         // TODO: make ignoring deleted values optional
 
         val values = multipartContent.parts
@@ -279,7 +279,6 @@ private[riak] class RiakHttpClientHelper(system: ActorSystem) extends RiakUriSup
         } else {
           successful(result)
         }
-      }
     }
   }
 

--- a/src/test/scala/com/scalapenos/riak/RiakBucketSpec.scala
+++ b/src/test/scala/com/scalapenos/riak/RiakBucketSpec.scala
@@ -60,9 +60,9 @@ class RiakBucketSpec extends RiakClientSpecification with RandomKeySupport with 
 
       (bucket.allowSiblings = true).await
 
-      val siblingValues= Set("value1", "value2", "value3")
+      val siblingValues = Set("value1", "value2", "value3")
 
-      for (value <- siblingValues) {
+      for (value ← siblingValues) {
         // we store values without VectorClock which causes siblings creation
         bucket.store(key, value).await
       }

--- a/src/test/scala/com/scalapenos/riak/RiakBucketSpec.scala
+++ b/src/test/scala/com/scalapenos/riak/RiakBucketSpec.scala
@@ -53,6 +53,52 @@ class RiakBucketSpec extends RiakClientSpecification with RandomKeySupport with 
 
       fetched should beNone
     }
-  }
 
+    "fetch all sibling values and return them to client if they exist for given Riak entry" in {
+      val bucket = randomBucket
+      val key = randomKey
+
+      (bucket.allowSiblings = true).await
+
+      val siblingValues= Set("value1", "value2", "value3")
+
+      for (value <- siblingValues) {
+        // we store values without VectorClock which causes siblings creation
+        bucket.store(key, value).await
+      }
+
+      val fetched = bucket.fetchWithSiblings(key).await
+
+      fetched should beSome
+      fetched.get.size should beEqualTo(3)
+      fetched.get.map(_.data) should beEqualTo(siblingValues)
+    }
+
+    "return a set containing a single value for given Riak entry if there are no siblings when fetching with siblings mode" in {
+      val bucket = randomBucket
+      val key = randomKey
+
+      (bucket.allowSiblings = true).await
+
+      val expectedValue = "value"
+      bucket.store(key, expectedValue).await
+
+      val fetched = bucket.fetchWithSiblings(key).await
+
+      fetched should beSome
+      fetched.get.size should beEqualTo(1)
+      fetched.get.map(_.data) should beEqualTo(Set(expectedValue))
+    }
+
+    "return an empty set for Riak entry that hasn't been found when fetching with siblings mode" in {
+      val bucket = randomBucket
+      val key = randomKey
+
+      (bucket.allowSiblings = true).await
+
+      val fetched = bucket.fetchWithSiblings(key).await
+
+      fetched should beNone
+    }
+  }
 }

--- a/src/test/scala/com/scalapenos/riak/RiakBucketSpec.scala
+++ b/src/test/scala/com/scalapenos/riak/RiakBucketSpec.scala
@@ -54,7 +54,7 @@ class RiakBucketSpec extends RiakClientSpecification with RandomKeySupport with 
       fetched should beNone
     }
 
-    "fetch all sibling values and return them to client if they exist for given Riak entry" in {
+    "fetch all sibling values and return them to the client if they exist for a given Riak entry" in {
       val bucket = randomBucket
       val key = randomKey
 

--- a/src/test/scala/com/scalapenos/riak/RiakBucketSpec.scala
+++ b/src/test/scala/com/scalapenos/riak/RiakBucketSpec.scala
@@ -90,7 +90,7 @@ class RiakBucketSpec extends RiakClientSpecification with RandomKeySupport with 
       fetched.get.map(_.data) should beEqualTo(Set(expectedValue))
     }
 
-    "return an empty set for Riak entry that hasn't been found when fetching with siblings mode" in {
+    "return None if entry hasn't been found when fetching with siblings mode" in {
       val bucket = randomBucket
       val key = randomKey
 


### PR DESCRIPTION
The idea behind a new 'fetchWithSiblings' operation is to give some more control to the user on how to deal with Riak siblings.
ConflictResolver is a neat functionality but sometimes user might need even more control.

For example, here is a sample scenario:
User wants to read a Riak entry first before update and check if there are any siblings already. If there are siblings then he might count them and stop performing further update operation if there are too many (according to certain threshold).
Such 'peek-before-store' strategy could be useful when dealing with 'Siblings explosion' cases, and we found ourselves implementing similar thing in our project recently.

Best regards,
Dmitry