### PR TITLE
support multiple backend

### DIFF
--- a/src/main/scala/com/scalapenos/riak/RiakBucketProperties.scala
+++ b/src/main/scala/com/scalapenos/riak/RiakBucketProperties.scala
@@ -82,6 +82,13 @@ case class LastWriteWins(value: Boolean) extends RiakBucketProperty[Boolean] {
   def json = JsBoolean(value)
 }
 
+case class BackendSelector(value: String) extends RiakBucketProperty[String] {
+  require(value.length > 0, "Backend can not be zero length")
+
+  def name = "backend"
+  def json = JsString(value)
+}
+
 /*
 {
     "props": {


### PR DESCRIPTION

I use Riak with multiple backend(persistence and cached). but riak-scala-client has no way for backend selector. I implements a quick way, but I think there is a better way to open `RiakBucketProperty`(without `seal`). How do you think about this?

Sorry for my poor English and thanks for your patience.