### PR TITLE
Conditional Fetch requests support

### DIFF
--- a/src/main/scala/com/scalapenos/riak/RiakBucket.scala
+++ b/src/main/scala/com/scalapenos/riak/RiakBucket.scala
@@ -78,9 +78,9 @@ object RiakBucket {
 
   sealed trait ConditionalRequestParam
 
-  case class IfNoneMatch(eTag: String) extends ConditionalRequestParam
+  case class IfNoneMatch(eTag: ETag) extends ConditionalRequestParam
 
-  case class IfMatch(eTag: String) extends ConditionalRequestParam
+  case class IfMatch(eTag: ETag) extends ConditionalRequestParam
 
   case class IfModified(timestamp: DateTime) extends ConditionalRequestParam
 

--- a/src/main/scala/com/scalapenos/riak/RiakBucket.scala
+++ b/src/main/scala/com/scalapenos/riak/RiakBucket.scala
@@ -19,6 +19,7 @@ package com.scalapenos.riak
 trait RiakBucket {
   import scala.concurrent.{ ExecutionContext, Future }
   import internal._
+  import RiakBucket._
 
   val name: String
 
@@ -28,7 +29,7 @@ trait RiakBucket {
    */
   def resolver: RiakConflictsResolver
 
-  def fetch(key: String): Future[Option[RiakValue]]
+  def fetch(key: String, conditionalParams: ConditionalRequestParam*): Future[Option[RiakValue]]
 
   def fetch(index: String, value: String): Future[List[RiakValue]] = fetch(RiakIndex(index, value))
   def fetch(index: String, value: Int): Future[List[RiakValue]] = fetch(RiakIndex(index, value))
@@ -71,4 +72,17 @@ trait RiakBucket {
   def setLastWriteWins(value: Boolean): Future[Unit] = setProperties(Set(LastWriteWins(value)))
 
   def unsafe: UnsafeBucketOperations
+}
+
+object RiakBucket {
+
+  sealed trait ConditionalRequestParam
+
+  case class IfNoneMatch(eTag: String) extends ConditionalRequestParam
+
+  case class IfMatch(eTag: String) extends ConditionalRequestParam
+
+  case class IfModified(timestamp: DateTime) extends ConditionalRequestParam
+
+  case class IfNotModified(timestamp: DateTime) extends ConditionalRequestParam
 }

--- a/src/main/scala/com/scalapenos/riak/RiakBucket.scala
+++ b/src/main/scala/com/scalapenos/riak/RiakBucket.scala
@@ -82,7 +82,7 @@ object RiakBucket {
 
   case class IfMatch(eTag: ETag) extends ConditionalRequestParam
 
-  case class IfModified(timestamp: DateTime) extends ConditionalRequestParam
+  case class IfModifiedSince(timestamp: DateTime) extends ConditionalRequestParam
 
-  case class IfUnmodified(timestamp: DateTime) extends ConditionalRequestParam
+  case class IfUnmodifiedSince(timestamp: DateTime) extends ConditionalRequestParam
 }

--- a/src/main/scala/com/scalapenos/riak/RiakBucket.scala
+++ b/src/main/scala/com/scalapenos/riak/RiakBucket.scala
@@ -87,7 +87,7 @@ object RiakBucket {
    *
    * @param eTag the target ETag value.
    */
-  case class IfNoneMatch(eTag: ETag) extends ConditionalRequestParam
+  case class IfNotMatch(eTag: ETag) extends ConditionalRequestParam
 
   /**
    * Perform a request on a RiakValue only if value's ETag matches the given one.

--- a/src/main/scala/com/scalapenos/riak/RiakBucket.scala
+++ b/src/main/scala/com/scalapenos/riak/RiakBucket.scala
@@ -76,13 +76,41 @@ trait RiakBucket {
 
 object RiakBucket {
 
+  /**
+   * Parameter for conditional request semantics.
+   * Can be used for Fetch Value and Store Value operations.
+   */
   sealed trait ConditionalRequestParam
 
+  /**
+   * Perform a request on a RiakValue only if value's ETag does not match the given one.
+   *
+   * @param eTag the target ETag value.
+   */
   case class IfNoneMatch(eTag: ETag) extends ConditionalRequestParam
 
+  /**
+   * Perform a request on a RiakValue only if value's ETag matches the given one.
+   *
+   * @param eTag the target ETag value.
+   */
   case class IfMatch(eTag: ETag) extends ConditionalRequestParam
 
+  /**
+   * Perform a request on a RiakValue only if value's Last-Modified time is after the given timestamp.
+   *
+   * @param timestamp
+   *
+   * *Note*: if target time is in the future then Riak always treats this condition as `true`.
+   */
   case class IfModifiedSince(timestamp: DateTime) extends ConditionalRequestParam
 
+  /**
+   * Perform a request on a RiakValue only if value's Last-Modified time is before the given timestamp.
+   *
+   * @param timestamp
+   *
+   * *Note*: if target time is in the future then Riak always treats this condition as `true`.
+   */
   case class IfUnmodifiedSince(timestamp: DateTime) extends ConditionalRequestParam
 }

--- a/src/main/scala/com/scalapenos/riak/RiakBucket.scala
+++ b/src/main/scala/com/scalapenos/riak/RiakBucket.scala
@@ -84,5 +84,5 @@ object RiakBucket {
 
   case class IfModified(timestamp: DateTime) extends ConditionalRequestParam
 
-  case class IfNotModified(timestamp: DateTime) extends ConditionalRequestParam
+  case class IfUnmodified(timestamp: DateTime) extends ConditionalRequestParam
 }

--- a/src/main/scala/com/scalapenos/riak/internal/RiakHttpBucket.scala
+++ b/src/main/scala/com/scalapenos/riak/internal/RiakHttpBucket.scala
@@ -17,8 +17,12 @@
 package com.scalapenos.riak
 package internal
 
+import RiakBucket._
+
 private[riak] sealed class RiakHttpBucket(helper: RiakHttpClientHelper, server: RiakServerInfo, val name: String, val resolver: RiakConflictsResolver) extends RiakBucket {
-  def fetch(key: String) = helper.fetch(server, name, key, resolver)
+
+  def fetch(key: String, conditionalParams: ConditionalRequestParam*) = helper.fetch(server, name, key, resolver, conditionalParams)
+
   def fetch(index: RiakIndex) = helper.fetch(server, name, index, resolver)
   def fetch(indexRange: RiakIndexRange) = helper.fetch(server, name, indexRange, resolver)
 

--- a/src/main/scala/com/scalapenos/riak/internal/RiakHttpClientHelper.scala
+++ b/src/main/scala/com/scalapenos/riak/internal/RiakHttpClientHelper.scala
@@ -67,7 +67,7 @@ private[riak] class RiakHttpClientHelper(system: ActorSystem) extends RiakHttpSu
     }
   }
 
-  def fetch(server: RiakServerInfo, bucket: String, key: String, resolver: RiakConflictsResolver, conditionalParams: ConditionalRequestParam*): Future[Option[RiakValue]] = {
+  def fetch(server: RiakServerInfo, bucket: String, key: String, resolver: RiakConflictsResolver, conditionalParams: Seq[ConditionalRequestParam] = Seq()): Future[Option[RiakValue]] = {
     httpRequest(Get(KeyUri(server, bucket, key)).withHeaders(conditionalParams.map(_.asHttpHeader): _*)).flatMap { response ⇒
       response.status match {
         case OK              ⇒ successful(toRiakValue(response))

--- a/src/main/scala/com/scalapenos/riak/internal/RiakHttpClientHelper.scala
+++ b/src/main/scala/com/scalapenos/riak/internal/RiakHttpClientHelper.scala
@@ -44,8 +44,6 @@ private[riak] class RiakHttpClientHelper(system: ActorSystem) extends RiakHttpSu
   import spray.httpx.SprayJsonSupport._
   import spray.json.DefaultJsonProtocol._
 
-  import org.slf4j.LoggerFactory
-
   import SprayClientExtras._
   import RiakHttpHeaders._
   import RiakHttpClientHelper._

--- a/src/main/scala/com/scalapenos/riak/internal/RiakHttpClientHelper.scala
+++ b/src/main/scala/com/scalapenos/riak/internal/RiakHttpClientHelper.scala
@@ -33,7 +33,7 @@ private[riak] object RiakHttpClientHelper {
   }
 }
 
-private[riak] class RiakHttpClientHelper(system: ActorSystem) extends RiakUriSupport with RiakIndexSupport with DateTimeSupport {
+private[riak] class RiakHttpClientHelper(system: ActorSystem) extends RiakHttpSupport with RiakIndexSupport with DateTimeSupport {
   import scala.concurrent.Future
   import scala.concurrent.Future._
 

--- a/src/main/scala/com/scalapenos/riak/internal/RiakHttpClientHelper.scala
+++ b/src/main/scala/com/scalapenos/riak/internal/RiakHttpClientHelper.scala
@@ -47,6 +47,7 @@ private[riak] class RiakHttpClientHelper(system: ActorSystem) extends RiakHttpSu
   import SprayClientExtras._
   import RiakHttpHeaders._
   import RiakHttpClientHelper._
+  import RiakBucket._
 
   import system.dispatcher
 
@@ -66,8 +67,8 @@ private[riak] class RiakHttpClientHelper(system: ActorSystem) extends RiakHttpSu
     }
   }
 
-  def fetch(server: RiakServerInfo, bucket: String, key: String, resolver: RiakConflictsResolver, conditionalRequestParams: List[ConditionalRequestParam] = Nil): Future[Option[RiakValue]] = {
-    httpRequest(Get(KeyUri(server, bucket, key)).withHeaders(conditionalRequestParams.map(_.asHeader))).flatMap { response ⇒
+  def fetch(server: RiakServerInfo, bucket: String, key: String, resolver: RiakConflictsResolver, conditionalParams: ConditionalRequestParam*): Future[Option[RiakValue]] = {
+    httpRequest(Get(KeyUri(server, bucket, key)).withHeaders(conditionalParams.map(_.asHttpHeader): _*)).flatMap { response ⇒
       response.status match {
         case OK              ⇒ successful(toRiakValue(response))
         case NotFound        ⇒ successful(None)

--- a/src/main/scala/com/scalapenos/riak/internal/RiakHttpClientHelper.scala
+++ b/src/main/scala/com/scalapenos/riak/internal/RiakHttpClientHelper.scala
@@ -66,14 +66,14 @@ private[riak] class RiakHttpClientHelper(system: ActorSystem) extends RiakHttpSu
     }
   }
 
-  def fetch(server: RiakServerInfo, bucket: String, key: String, resolver: RiakConflictsResolver): Future[Option[RiakValue]] = {
-    httpRequest(Get(KeyUri(server, bucket, key))).flatMap { response ⇒
+  def fetch(server: RiakServerInfo, bucket: String, key: String, resolver: RiakConflictsResolver, conditionalRequestParams: List[ConditionalRequestParam] = Nil): Future[Option[RiakValue]] = {
+    httpRequest(Get(KeyUri(server, bucket, key)).withHeaders(conditionalRequestParams.map(_.asHeader))).flatMap { response ⇒
       response.status match {
         case OK              ⇒ successful(toRiakValue(response))
         case NotFound        ⇒ successful(None)
+        case NotModified     ⇒ successful(None) // This means that client is not able to distinguish cases when value is not in Riak or a supplied condition is not met.
         case MultipleChoices ⇒ resolveConflict(server, bucket, key, response, resolver).map(Some(_))
         case other           ⇒ throw new BucketOperationFailed(s"Fetch for key '$key' in bucket '$bucket' produced an unexpected response code '$other'.")
-        // TODO: case NotModified => successful(None)
       }
     }
   }

--- a/src/main/scala/com/scalapenos/riak/internal/RiakHttpSupport.scala
+++ b/src/main/scala/com/scalapenos/riak/internal/RiakHttpSupport.scala
@@ -48,7 +48,7 @@ private[riak] trait RiakHttpSupport {
         case IfModifiedSince(date)   ⇒ `If-Modified-Since`(toSprayDateTime(date))
         case IfUnmodifiedSince(date) ⇒ `If-Unmodified-Since`(toSprayDateTime(date))
         case IfMatch(eTag)           ⇒ RawHeader("If-Match", eTag.value) // TODO this `If-Match`(EntityTag(eTag)) doesn't work as spray escapes double quotes in ETag value
-        case IfNoneMatch(eTag)       ⇒ RawHeader("If-None-Match", eTag.value) // TODO this `If-None-Match`(EntityTag(eTag)) doesn't work as spray escapes double quotes in ETag value
+        case IfNotMatch(eTag)        ⇒ RawHeader("If-None-Match", eTag.value) // TODO this `If-None-Match`(EntityTag(eTag)) doesn't work as spray escapes double quotes in ETag value
         case _                       ⇒ throw new IllegalArgumentException("Unknown conditional request param: cannot convert to HTTP header.")
       }
     }

--- a/src/main/scala/com/scalapenos/riak/internal/RiakHttpSupport.scala
+++ b/src/main/scala/com/scalapenos/riak/internal/RiakHttpSupport.scala
@@ -45,10 +45,10 @@ private[riak] trait RiakHttpSupport {
   implicit class ConditionalHttpRequestParam(conditionalParam: ConditionalRequestParam) {
     def asHttpHeader: HttpHeader = {
       conditionalParam match {
-        case IfMatch(eTag)       ⇒ `If-Match`(EntityTag(eTag))
-        case IfNoneMatch(eTag)   ⇒ `If-None-Match`(EntityTag(eTag))
         case IfModifiedSince(date)    ⇒ `If-Modified-Since`(toSprayDateTime(date))
         case IfUnmodifiedSince(date) ⇒ `If-Unmodified-Since`(toSprayDateTime(date))
+        case IfMatch(eTag)       ⇒ RawHeader("If-Match", eTag.value) // TODO this `If-Match`(EntityTag(eTag)) doesn't work as spray escapes double quotes in ETag value
+        case IfNoneMatch(eTag)   ⇒ RawHeader("If-None-Match", eTag.value) // TODO this `If-None-Match`(EntityTag(eTag)) doesn't work as spray escapes double quotes in ETag value
         case _                   ⇒ throw new IllegalArgumentException("Unknown conditional request param: cannot convert to HTTP header.")
       }
     }

--- a/src/main/scala/com/scalapenos/riak/internal/RiakHttpSupport.scala
+++ b/src/main/scala/com/scalapenos/riak/internal/RiakHttpSupport.scala
@@ -17,9 +17,9 @@
 package com.scalapenos.riak
 package internal
 
-private[riak] trait RiakUriSupport {
-  import spray.http.Uri
-  import spray.http.Uri._
+private[riak] trait RiakHttpSupport {
+  import spray.http.{ Uri, HttpHeader, HttpHeaders, EntityTag }, HttpHeaders._, Uri._
+  import DateTimeSupport._
 
   // ==========================================================================
   // Query Parameters
@@ -35,6 +35,30 @@ private[riak] trait RiakUriSupport {
 
   case class StoreQueryParameters(returnBody: Boolean = false) extends QueryParameters {
     def query = ("returnbody", s"$returnBody") +: Query.Empty
+  }
+
+  // ==========================================================================
+  // Conditional Request Parameters
+  // ==========================================================================
+
+  sealed trait ConditionalRequestParam {
+    def asHeader: HttpHeader
+  }
+
+  case class IfNoneMatch(eTag: String) extends ConditionalRequestParam {
+    def asHeader: HttpHeader = `If-None-Match`(EntityTag(eTag))
+  }
+
+  case class IfMatch(eTag: String) extends ConditionalRequestParam {
+    def asHeader: HttpHeader = `If-Match`(EntityTag(eTag))
+  }
+
+  case class IfModified(timestamp: DateTime) extends ConditionalRequestParam {
+    def asHeader: HttpHeader = `If-Modified-Since`(toSprayDateTime(timestamp))
+  }
+
+  case class IfNotModified(timestamp: DateTime) extends ConditionalRequestParam {
+    def asHeader: HttpHeader = `If-Unmodified-Since`(toSprayDateTime(timestamp))
   }
 
   // ==========================================================================

--- a/src/main/scala/com/scalapenos/riak/internal/RiakHttpSupport.scala
+++ b/src/main/scala/com/scalapenos/riak/internal/RiakHttpSupport.scala
@@ -45,10 +45,10 @@ private[riak] trait RiakHttpSupport {
   implicit class ConditionalHttpRequestParam(conditionalParam: ConditionalRequestParam) {
     def asHttpHeader: HttpHeader = {
       conditionalParam match {
-        case IfModified(date)    ⇒ `If-Modified-Since`(toSprayDateTime(date))
         case IfMatch(eTag)       ⇒ `If-Match`(EntityTag(eTag))
         case IfNoneMatch(eTag)   ⇒ `If-None-Match`(EntityTag(eTag))
-        case IfUnmodified(date) ⇒ `If-Unmodified-Since`(toSprayDateTime(date))
+        case IfModifiedSince(date)    ⇒ `If-Modified-Since`(toSprayDateTime(date))
+        case IfUnmodifiedSince(date) ⇒ `If-Unmodified-Since`(toSprayDateTime(date))
         case _                   ⇒ throw new IllegalArgumentException("Unknown conditional request param: cannot convert to HTTP header.")
       }
     }

--- a/src/main/scala/com/scalapenos/riak/internal/RiakHttpSupport.scala
+++ b/src/main/scala/com/scalapenos/riak/internal/RiakHttpSupport.scala
@@ -45,11 +45,11 @@ private[riak] trait RiakHttpSupport {
   implicit class ConditionalHttpRequestParam(conditionalParam: ConditionalRequestParam) {
     def asHttpHeader: HttpHeader = {
       conditionalParam match {
-        case IfModifiedSince(date)    ⇒ `If-Modified-Since`(toSprayDateTime(date))
+        case IfModifiedSince(date)   ⇒ `If-Modified-Since`(toSprayDateTime(date))
         case IfUnmodifiedSince(date) ⇒ `If-Unmodified-Since`(toSprayDateTime(date))
-        case IfMatch(eTag)       ⇒ RawHeader("If-Match", eTag.value) // TODO this `If-Match`(EntityTag(eTag)) doesn't work as spray escapes double quotes in ETag value
-        case IfNoneMatch(eTag)   ⇒ RawHeader("If-None-Match", eTag.value) // TODO this `If-None-Match`(EntityTag(eTag)) doesn't work as spray escapes double quotes in ETag value
-        case _                   ⇒ throw new IllegalArgumentException("Unknown conditional request param: cannot convert to HTTP header.")
+        case IfMatch(eTag)           ⇒ RawHeader("If-Match", eTag.value) // TODO this `If-Match`(EntityTag(eTag)) doesn't work as spray escapes double quotes in ETag value
+        case IfNoneMatch(eTag)       ⇒ RawHeader("If-None-Match", eTag.value) // TODO this `If-None-Match`(EntityTag(eTag)) doesn't work as spray escapes double quotes in ETag value
+        case _                       ⇒ throw new IllegalArgumentException("Unknown conditional request param: cannot convert to HTTP header.")
       }
     }
   }

--- a/src/main/scala/com/scalapenos/riak/internal/RiakHttpSupport.scala
+++ b/src/main/scala/com/scalapenos/riak/internal/RiakHttpSupport.scala
@@ -46,9 +46,9 @@ private[riak] trait RiakHttpSupport {
     def asHttpHeader: HttpHeader = {
       conditionalParam match {
         case IfModified(date)    ⇒ `If-Modified-Since`(toSprayDateTime(date))
-        case IfNotModified(date) ⇒ `If-Unmodified-Since`(toSprayDateTime(date))
         case IfMatch(eTag)       ⇒ `If-Match`(EntityTag(eTag))
         case IfNoneMatch(eTag)   ⇒ `If-None-Match`(EntityTag(eTag))
+        case IfUnmodified(date) ⇒ `If-Unmodified-Since`(toSprayDateTime(date))
         case _                   ⇒ throw new IllegalArgumentException("Unknown conditional request param: cannot convert to HTTP header.")
       }
     }

--- a/src/test/scala/com/scalapenos/riak/RiakBucketSpec.scala
+++ b/src/test/scala/com/scalapenos/riak/RiakBucketSpec.scala
@@ -107,7 +107,7 @@ class RiakBucketSpec extends RiakClientSpecification with RandomKeySupport with 
 
       bucket.storeAndFetch(key, "value").await
 
-      bucket.fetch(key, IfModifiedSince(DateTime.now.plusMinutes(5))).await must beNone
+      bucket.fetch(key, IfModifiedSince(DateTime.now)).await must beNone
     }
 
     "return back a stored value if 'If-Modified-Since' condition holds for requested data" in {

--- a/src/test/scala/com/scalapenos/riak/RiakBucketSpec.scala
+++ b/src/test/scala/com/scalapenos/riak/RiakBucketSpec.scala
@@ -16,7 +16,7 @@
 
 package com.scalapenos.riak
 
-import com.scalapenos.riak.RiakBucket.{IfMatch, IfModifiedSince, IfNoneMatch, IfUnmodifiedSince}
+import com.scalapenos.riak.RiakBucket.{ IfMatch, IfModifiedSince, IfNotMatch, IfUnmodifiedSince }
 import org.joda.time.DateTime
 
 class RiakBucketSpec extends RiakClientSpecification with RandomKeySupport with RandomBucketSupport {
@@ -69,7 +69,7 @@ class RiakBucketSpec extends RiakClientSpecification with RandomKeySupport with 
 
       val eTag = storedValue.etag
 
-      bucket.fetch(key, IfNoneMatch(eTag)).await must beNone
+      bucket.fetch(key, IfNotMatch(eTag)).await must beNone
     }
 
     "return back a stored value if 'If-None-Match' condition holds for requested data" in {
@@ -78,7 +78,7 @@ class RiakBucketSpec extends RiakClientSpecification with RandomKeySupport with 
 
       val storedValue = bucket.storeAndFetch(key, "value").await
 
-      bucket.fetch(key, IfNoneMatch(randomKey)).await must beSome(storedValue)
+      bucket.fetch(key, IfNotMatch(randomKey)).await must beSome(storedValue)
     }
 
     "not return back a stored value if 'If-Match' condition does not hold for a requested data" in {


### PR DESCRIPTION
## Overview

Introduces support for conditional request parameters when fetching a value from Riak bucket.

Riak Fetch Object (HTTP API) parameters are described in here:
http://docs.basho.com/riak/kv/2.1.4/developing/api/http/fetch-object/#request

Supported conditions:
- _IfMatch_ - fetch a value if it has the same ETag.
- _IfNotMatch_ - fetch a value if it has a different ETag.
- _IfModifiedSince_ - fetch a value if it has been modified (_Last-Modified_ attribute) since a specific time.
- _IfUnmodifiedSince_ - fetch a value if it has been modified (_Last-Modified_ attribute) since a specific time.

Conditions can be combined together.
## Compatibility

This change is backwards compatible with existing code that uses the library. 
## Tests

Tested with integration specs (**RiakBucketSpec.scala**) against Riak 1.4 (_1.4.10_) and Riak 2 (_2.1.1_).
## Future improvements

Conditional parameters support can be expanded also to Store Object API:
http://docs.basho.com/riak/kv/2.1.4/developing/api/http/store-object/#request

It works the same way in Riak.
## Support of other API backends

**Note** that the conditional requests support in **Protobuf API** is a bit different:
http://docs.basho.com/riak/kv/2.1.4/developing/api/protocol-buffers/fetch-object/#request
- No support of conditions based on _Last-Modified_ attribute.
- If(Not)Match conditions are based on VClocks, not ETags.

So HTTP API and Protobuf API are not on par in that sense.
