### PR TITLE
Gzip compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Other features include:
     - builtin spray-json (de)serializers
 - Automatic indexing of Scala (case) classes using type classes
 - Auto-retry of fetches and stores (a standard feature of the underlying spray-client library)
+- Optional compression of Riak HTTP **responses** (see _enable-http-compression_ setting).
 
 The following Riak (http) API features are not supported at this time:
 
@@ -88,6 +89,16 @@ The riak-scala-client has been tested against [Riak] versions 1.2.x, 1.3.x, 1.4.
   And earlier version did manual double URL encoding/decoding but that was not a
   sustainable solution. Please avoid using characters like ' ', ',', '?', '&', etc.
   in index names and index values for now.
+- HTTP compression, when enabled (_enable-http-compression = true_), is only used for **Riak responses**.
+  Request payloads are sent to Riak as they are due to a number of known limitations: 
+    - Riak value that has been stored with a non-empty `Content-Encoding` header is always served by Riak 
+    with that encoding, regardless the value of `Accept-Encoding` _fetch object request_ header.
+    See https://github.com/agemooij/riak-scala-client/issues/42 for details.
+    - Riak _set bucket properties_ endpoint doesn't handle compressed payloads properly.
+    See https://github.com/agemooij/riak-scala-client/issues/41 for details.
+    - Delete requests with `Accept-Encoding: gzip` header may be served with `HTTP 404 Not Found` responses 
+    which have `Content-Encoding: gzip` header, but `text/plain` body.
+    See https://github.com/agemooij/riak-scala-client/issues/43 for details.
 
 
 ## Why such a boring name?

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -24,6 +24,9 @@ riak {
     ignore-tombstones = yes
 
     # Should the client use an compression (e.g. Gzip) when talking to Riak via HTTP.
+    # *Note* that only enables compressed *responses* from Riak.
+    # Requests are sent 'as is', without any compression.
+    # This is done due to a number of known problems on Riak side in regards to handling those.
     enable-http-compression = no
 }
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -24,7 +24,7 @@ riak {
     ignore-tombstones = yes
 
     # Should the client use an compression (e.g. Gzip) when talking to Riak via HTTP.
-    enable-http-compression = yes
+    enable-http-compression = no
 }
 
 spray.can.client {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -22,6 +22,9 @@ riak {
     #
     # Riak server designates values as tombstones by adding an optional 'X-Riak-Deleted' header.
     ignore-tombstones = yes
+
+    # Should the client use an compression (e.g. Gzip) when talking to Riak via HTTP.
+    enable-http-compression = yes
 }
 
 spray.can.client {

--- a/src/main/scala/com/scalapenos/riak/internal/RiakClientSettings.scala
+++ b/src/main/scala/com/scalapenos/riak/internal/RiakClientSettings.scala
@@ -45,7 +45,10 @@ private[riak] class RiakClientSettings(config: Config) {
 
   /**
    * Setting for controlling whether the Riak client should use a compression (e.g. Gzip)
-   * when sending and receiving data via HTTP connection to Riak.
+   * when *receiving* data via HTTP connection from Riak.
+   *
+   * *Note* that this settings does not enable requests payload compression.
+   * This is done due to a number of known problems on Riak side in regards to handling compressed requests.
    *
    * This value defaults to *false*.
    */

--- a/src/main/scala/com/scalapenos/riak/internal/RiakClientSettings.scala
+++ b/src/main/scala/com/scalapenos/riak/internal/RiakClientSettings.scala
@@ -47,7 +47,7 @@ private[riak] class RiakClientSettings(config: Config) {
    * Setting for controlling whether the Riak client should use a compression (e.g. Gzip)
    * when sending and receiving data via HTTP connection to Riak.
    *
-   * This value defaults to true.
+   * This value defaults to *false*.
    */
   final val EnableHttpCompression: Boolean = config.getBoolean("riak.enable-http-compression")
 

--- a/src/main/scala/com/scalapenos/riak/internal/RiakClientSettings.scala
+++ b/src/main/scala/com/scalapenos/riak/internal/RiakClientSettings.scala
@@ -43,6 +43,14 @@ private[riak] class RiakClientSettings(config: Config) {
    */
   final val IgnoreTombstones: Boolean = config.getBoolean("riak.ignore-tombstones")
 
+  /**
+   * Setting for controlling whether the Riak client should use a compression (e.g. Gzip)
+   * when sending and receiving data via HTTP connection to Riak.
+   *
+   * This value defaults to true.
+   */
+  final val EnableHttpCompression: Boolean = config.getBoolean("riak.enable-http-compression")
+
   // TODO: add setting for silently ignoring indexes on backends that don't allow them. The alternative is failing/throwing exceptions
 
 }

--- a/src/main/scala/com/scalapenos/riak/internal/RiakHttpClientHelper.scala
+++ b/src/main/scala/com/scalapenos/riak/internal/RiakHttpClientHelper.scala
@@ -384,6 +384,11 @@ private[internal] object FixedMultipartContentUnmarshalling {
     }
 
   private def decompressData(headers: List[HttpHeader], decoder: Decoder, data: Array[Byte]): Array[Byte] = {
+    // According to RFC (https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html),
+    // "If multiple encodings have been applied to an entity, the content codings MUST be listed in the order in which
+    // they were applied. Additional information about the encoding parameters MAY be provided by other entity-header
+    // fields not defined by this specification."
+    // This means that, if there were multiple encodings applied, this will NOT work.
     if (headers.findByType[`Content-Encoding`].exists(_.encoding == decoder.encoding)) {
       decoder.newDecompressor.decompress(data)
     } else {

--- a/src/main/scala/com/scalapenos/riak/internal/RiakHttpClientHelper.scala
+++ b/src/main/scala/com/scalapenos/riak/internal/RiakHttpClientHelper.scala
@@ -42,7 +42,6 @@ private[riak] class RiakHttpClientHelper(system: ActorSystem) extends RiakUriSup
   import spray.http.StatusCodes._
   import spray.http.HttpHeaders._
   import spray.httpx.SprayJsonSupport._
-  import spray.httpx.encoding.Decoder
   import spray.httpx.encoding.Gzip
   import spray.json.DefaultJsonProtocol._
 
@@ -246,7 +245,6 @@ private[riak] class RiakHttpClientHelper(system: ActorSystem) extends RiakUriSup
   }
 
   private def dateTimeFromLastModified(lm: `Last-Modified`): DateTime = fromSprayDateTime(lm.date)
-  private def lastModifiedFromDateTime(dateTime: DateTime): `Last-Modified` = `Last-Modified`(toSprayDateTime(dateTime))
 
   // ==========================================================================
   // Index result fetching

--- a/src/main/scala/com/scalapenos/riak/internal/RiakHttpClientHelper.scala
+++ b/src/main/scala/com/scalapenos/riak/internal/RiakHttpClientHelper.scala
@@ -211,7 +211,7 @@ private[riak] class RiakHttpClientHelper(system: ActorSystem) extends RiakUriSup
    */
   private def safeDecodeGzip: ResponseTransformer = { response ⇒
     Try(decode(Gzip).apply(response)).recover {
-      // recover from a ZipException: this means that, although the response has a "Content-Encoding: gzip" header, but it's payload is not gzipped.
+      // recover from a ZipException: this means that, although the response has a "Content-Encoding: gzip" header, but its payload is not gzipped.
       case e: ZipException ⇒ response
     }.get
   }

--- a/src/main/scala/com/scalapenos/riak/internal/RiakHttpClientHelper.scala
+++ b/src/main/scala/com/scalapenos/riak/internal/RiakHttpClientHelper.scala
@@ -210,6 +210,7 @@ private[riak] class RiakHttpClientHelper(system: ActorSystem) extends RiakUriSup
       // Well, there is a surprise from Riak: it will respond with gzip anyway if previous `store value` request was performed with `Content-Encoding: gzip` header! o_O
       // Yes, it's that weird...
       // And adding `addHeader(`Accept-Encoding`(NoEncoding.encoding))` directive for request will break it: Riak might respond with '406 Not Acceptable'
+      // Issue for tracking: https://github.com/agemooij/riak-scala-client/issues/42
       sendReceive ~> decode(Gzip)
     }
   }
@@ -274,6 +275,7 @@ private[riak] class RiakHttpClientHelper(system: ActorSystem) extends RiakUriSup
 
     implicit val FixedMultipartContentUnmarshaller =
       // we always pass a Gzip decoder. Just in case if Riak decides to respond with gzip suddenly. o_O
+      // Issue for tracking: https://github.com/agemooij/riak-scala-client/issues/42
       multipartContentUnmarshaller(HttpCharsets.`UTF-8`, decoder = Gzip)
 
     val vclockHeader = response.headers.find(_.is(`X-Riak-Vclock`.toLowerCase)).toList
@@ -306,6 +308,7 @@ private[riak] class RiakHttpClientHelper(system: ActorSystem) extends RiakUriSup
 
     implicit val FixedMultipartContentUnmarshaller =
       // we always pass a Gzip decoder. Just in case if Riak decides to respond with gzip suddenly. o_O
+      // Issue for tracking: https://github.com/agemooij/riak-scala-client/issues/42
       multipartContentUnmarshaller(HttpCharsets.`UTF-8`, decoder = Gzip)
 
     val vclockHeader = response.headers.find(_.is(`X-Riak-Vclock`.toLowerCase)).toList

--- a/src/main/scala/com/scalapenos/riak/internal/RiakHttpClientHelper.scala
+++ b/src/main/scala/com/scalapenos/riak/internal/RiakHttpClientHelper.scala
@@ -202,7 +202,7 @@ private[riak] class RiakHttpClientHelper(system: ActorSystem) extends RiakUriSup
   private lazy val clientId = java.util.UUID.randomUUID().toString
   private val clientIdHeader = if (settings.AddClientIdHeader) Some(RawHeader(`X-Riak-ClientId`, clientId)) else None
 
-  private val basePipeline = {
+  private def basePipeline = {
     if (settings.EnableHttpCompression) {
       addHeader(`Accept-Encoding`(Gzip.encoding)) ~>
         encode(Gzip) ~>

--- a/src/main/scala/com/scalapenos/riak/internal/RiakHttpClientHelper.scala
+++ b/src/main/scala/com/scalapenos/riak/internal/RiakHttpClientHelper.scala
@@ -205,7 +205,6 @@ private[riak] class RiakHttpClientHelper(system: ActorSystem) extends RiakUriSup
   private val basePipeline = {
     if (settings.EnableHttpCompression) {
       addHeader(`Accept-Encoding`(Gzip.encoding)) ~>
-        addHeader(`Content-Encoding`.apply(Gzip.encoding)) ~>
         encode(Gzip) ~>
         sendReceive ~>
         decode(Gzip)

--- a/src/main/scala/com/scalapenos/riak/internal/RiakHttpClientHelper.scala
+++ b/src/main/scala/com/scalapenos/riak/internal/RiakHttpClientHelper.scala
@@ -166,6 +166,7 @@ private[riak] class RiakHttpClientHelper(system: ActorSystem) extends RiakUriSup
 
     // For some reason, Riak set bucket props HTTP endpoint doesn't handle compressed request properly.
     // So we disable compression for this request unconditionally.
+    // Issue for tracking: https://github.com/agemooij/riak-scala-client/issues/41
     httpRequest(enableCompression = false)(Put(PropertiesUri(server, bucket), entity)).map { response ⇒
       response.status match {
         case NoContent            ⇒ ()

--- a/src/main/scala/com/scalapenos/riak/internal/RiakHttpClientHelper.scala
+++ b/src/main/scala/com/scalapenos/riak/internal/RiakHttpClientHelper.scala
@@ -18,8 +18,7 @@ package com.scalapenos.riak
 package internal
 
 import akka.actor._
-import spray.http.HttpEncodingRange
-import spray.httpx.encoding.{ Decompressor, Encoder, GzipCompressor, GzipDecompressor }
+import spray.httpx.encoding.{ Decompressor, GzipDecompressor }
 
 private[riak] object RiakHttpClientHelper {
   import spray.http.HttpEntity
@@ -44,10 +43,8 @@ private[riak] class RiakHttpClientHelper(system: ActorSystem) extends RiakUriSup
   import spray.http.StatusCodes._
   import spray.http.HttpHeaders._
   import spray.httpx.SprayJsonSupport._
-  import spray.httpx.encoding.{ Gzip, Deflate }
+  import spray.httpx.encoding.Gzip
   import spray.json.DefaultJsonProtocol._
-
-  import org.slf4j.LoggerFactory
 
   import SprayClientExtras._
   import RiakHttpHeaders._

--- a/src/test/scala/com/scalapenos/riak/BasicInteractionsSpec.scala
+++ b/src/test/scala/com/scalapenos/riak/BasicInteractionsSpec.scala
@@ -16,11 +16,13 @@
 
 package com.scalapenos.riak
 
-class BasicInteractionsSpec extends AkkaActorSystemSpecification {
-  "The riak client" should {
+import java.util.UUID.randomUUID
+
+class BasicInteractionsSpec extends RiakClientSpecification {
+
+  "The Riak client" should {
     "be able to perform a simple get-put-get-delete-get CRUD flow" in {
-      val connection = RiakClient(defaultSystem)
-      val bucket = connection.bucket("test-basic-interaction")
+      val bucket = client.bucket(s"test-basic-interaction-$randomUUID")
 
       val fetchBeforeStore = bucket.fetch("foo")
 

--- a/src/test/scala/com/scalapenos/riak/BasicInteractionsSpec.scala
+++ b/src/test/scala/com/scalapenos/riak/BasicInteractionsSpec.scala
@@ -44,5 +44,4 @@ class BasicInteractionsSpec extends RiakClientSpecification {
       fetchAfterDelete must beNone
     }
   }
-
 }

--- a/src/test/scala/com/scalapenos/riak/BasicInteractionsSpec.scala
+++ b/src/test/scala/com/scalapenos/riak/BasicInteractionsSpec.scala
@@ -19,7 +19,7 @@ package com.scalapenos.riak
 class BasicInteractionsSpec extends AkkaActorSystemSpecification {
   "The riak client" should {
     "be able to perform a simple get-put-get-delete-get CRUD flow" in {
-      val connection = RiakClient(system)
+      val connection = RiakClient(defaultSystem)
       val bucket = connection.bucket("test-basic-interaction")
 
       val fetchBeforeStore = bucket.fetch("foo")

--- a/src/test/scala/com/scalapenos/riak/ConflictResolutionSpec.scala
+++ b/src/test/scala/com/scalapenos/riak/ConflictResolutionSpec.scala
@@ -152,5 +152,4 @@ class ConflictResolutionSpec extends RiakClientSpecification with RandomKeySuppo
       bucket.fetch(key).await must throwA[ConflicResolutionNotImplemented]
     }
   }
-
 }

--- a/src/test/scala/com/scalapenos/riak/RiakBucketPropertiesSpec.scala
+++ b/src/test/scala/com/scalapenos/riak/RiakBucketPropertiesSpec.scala
@@ -16,12 +16,11 @@
 
 package com.scalapenos.riak
 
-class RiakBucketPropertiesSpec extends RiakClientSpecification with RandomKeySupport {
-  private def randomBucket = client.bucket("riak-bucket-tests-" + randomKey)
+class RiakBucketPropertiesSpec extends RiakClientSpecification with RandomBucketSupport with RandomKeySupport {
 
   "A RiakBucket" should {
     "support setting and getting the bucket properties" in {
-      val bucket = randomBucket
+      val bucket = randomBucket(client)
       val oldProperties = bucket.properties.await
 
       val newNumberOfReplicas = oldProperties.numberOfReplicas + 1
@@ -49,7 +48,7 @@ class RiakBucketPropertiesSpec extends RiakClientSpecification with RandomKeySup
     }
 
     "support setting the bucket properties with an empty set (nothing happens)" in {
-      val bucket = randomBucket
+      val bucket = randomBucket(client)
       val oldProperties = bucket.properties.await
 
       bucket.setProperties(Set()).await
@@ -60,7 +59,7 @@ class RiakBucketPropertiesSpec extends RiakClientSpecification with RandomKeySup
     }
 
     "support directly setting the 'n_val' bucket property" in {
-      val bucket = randomBucket
+      val bucket = randomBucket(client)
 
       (bucket.numberOfReplicas = 5).await
       bucket.numberOfReplicas.await must beEqualTo(5)
@@ -70,7 +69,7 @@ class RiakBucketPropertiesSpec extends RiakClientSpecification with RandomKeySup
     }
 
     "support directly setting the 'allow_mult' bucket property" in {
-      val bucket = randomBucket
+      val bucket = randomBucket(client)
 
       (bucket.allowSiblings = true).await
       bucket.allowSiblings.await must beTrue
@@ -80,7 +79,7 @@ class RiakBucketPropertiesSpec extends RiakClientSpecification with RandomKeySup
     }
 
     "support directly setting the 'last_write_wins' bucket property" in {
-      val bucket = randomBucket
+      val bucket = randomBucket(client)
 
       (bucket.lastWriteWins = true).await
       bucket.lastWriteWins.await must beTrue
@@ -90,7 +89,7 @@ class RiakBucketPropertiesSpec extends RiakClientSpecification with RandomKeySup
     }
 
     "fail when directly setting the 'n_val' bucket property to any integer smaller than 1" in {
-      val bucket = randomBucket
+      val bucket = randomBucket(client)
 
       (bucket.numberOfReplicas = 0).await must throwA[IllegalArgumentException]
       (bucket.numberOfReplicas = -1).await must throwA[IllegalArgumentException]
@@ -103,5 +102,4 @@ class RiakBucketPropertiesSpec extends RiakClientSpecification with RandomKeySup
       NumberOfReplicas(-42) must throwA[IllegalArgumentException]
     }
   }
-
 }

--- a/src/test/scala/com/scalapenos/riak/RiakBucketSpec.scala
+++ b/src/test/scala/com/scalapenos/riak/RiakBucketSpec.scala
@@ -18,94 +18,87 @@ package com.scalapenos.riak
 
 class RiakBucketSpec extends RiakClientSpecification with RandomKeySupport with RandomBucketSupport {
 
-  Seq(true, false) foreach { enableCompression ⇒
-    s"When compression is ${if (enableCompression) "enabled" else "disabled"}" in {
+  "A RiakBucket" should {
+    "not be able to store an empty String value" in {
+      val bucket = randomBucket(client)
+      val key = randomKey
 
-      implicit val customClient = createRiakClient(enableCompression)
+      // Riak will reject the request with a 400 because the request will
+      // not have a body (because Spray doesn't allow empty bodies).
+      bucket.store(key, "").await must throwA[BucketOperationFailed]
+    }
 
-      "A RiakBucket" should {
-        "not be able to store an empty String value" in {
-          val bucket = randomBucket
-          val key = randomKey
+    "treat tombstone values as if they don't exist when allow_mult = false" in {
+      val bucket = randomBucket(client)
+      val key = randomKey
 
-          // Riak will reject the request with a 400 because the request will
-          // not have a body (because Spray doesn't allow empty bodies).
-          bucket.store(key, "").await must throwA[BucketOperationFailed]
-        }
+      bucket.store(key, "value").await
+      bucket.delete(key).await
 
-        "treat tombstone values as if they don't exist when allow_mult = false" in {
-          val bucket = randomBucket
-          val key = randomKey
+      val fetched = bucket.fetch(key).await
 
-          bucket.store(key, "value").await
-          bucket.delete(key).await
+      fetched should beNone
+    }
 
-          val fetched = bucket.fetch(key).await
+    "treat tombstone values as if they don't exist when allow_mult = true" in {
+      val bucket = randomBucket(client)
+      val key = randomKey
 
-          fetched should beNone
-        }
+      (bucket.allowSiblings = true).await
 
-        "treat tombstone values as if they don't exist when allow_mult = true" in {
-          val bucket = randomBucket
-          val key = randomKey
+      bucket.store(key, "value").await
+      bucket.delete(key).await
 
-          (bucket.allowSiblings = true).await
+      val fetched = bucket.fetch(key).await
 
-          bucket.store(key, "value").await
-          bucket.delete(key).await
+      fetched should beNone
+    }
 
-          val fetched = bucket.fetch(key).await
+    "fetch all sibling values and return them to the client if they exist for a given Riak entry" in {
+      val bucket = randomBucket(client)
+      val key = randomKey
 
-          fetched should beNone
-        }
+      (bucket.allowSiblings = true).await
 
-        "fetch all sibling values and return them to the client if they exist for a given Riak entry" in {
-          val bucket = randomBucket
-          val key = randomKey
+      val siblingValues = Set("value1", "value2", "value3")
 
-          (bucket.allowSiblings = true).await
-
-          val siblingValues = Set("value1", "value2", "value3")
-
-          for (value ← siblingValues) {
-            // we store values without VectorClock which causes siblings creation
-            bucket.store(key, value).await
-          }
-
-          val fetched = bucket.fetchWithSiblings(key).await
-
-          fetched should beSome
-          fetched.get.size should beEqualTo(3)
-          fetched.get.map(_.data) should beEqualTo(siblingValues)
-        }
-
-        "return a set containing a single value for given Riak entry if there are no siblings when fetching with siblings mode" in {
-          val bucket = randomBucket
-          val key = randomKey
-
-          (bucket.allowSiblings = true).await
-
-          val expectedValue = "value"
-          bucket.store(key, expectedValue).await
-
-          val fetched = bucket.fetchWithSiblings(key).await
-
-          fetched should beSome
-          fetched.get.size should beEqualTo(1)
-          fetched.get.map(_.data) should beEqualTo(Set(expectedValue))
-        }
-
-        "return None if entry hasn't been found when fetching with siblings mode" in {
-          val bucket = randomBucket
-          val key = randomKey
-
-          (bucket.allowSiblings = true).await
-
-          val fetched = bucket.fetchWithSiblings(key).await
-
-          fetched should beNone
-        }
+      for (value ← siblingValues) {
+        // we store values without VectorClock which causes siblings creation
+        bucket.store(key, value).await
       }
+
+      val fetched = bucket.fetchWithSiblings(key).await
+
+      fetched should beSome
+      fetched.get.size should beEqualTo(3)
+      fetched.get.map(_.data) should beEqualTo(siblingValues)
+    }
+
+    "return a set containing a single value for given Riak entry if there are no siblings when fetching with siblings mode" in {
+      val bucket = randomBucket(client)
+      val key = randomKey
+
+      (bucket.allowSiblings = true).await
+
+      val expectedValue = "value"
+      bucket.store(key, expectedValue).await
+
+      val fetched = bucket.fetchWithSiblings(key).await
+
+      fetched should beSome
+      fetched.get.size should beEqualTo(1)
+      fetched.get.map(_.data) should beEqualTo(Set(expectedValue))
+    }
+
+    "return None if entry hasn't been found when fetching with siblings mode" in {
+      val bucket = randomBucket(client)
+      val key = randomKey
+
+      (bucket.allowSiblings = true).await
+
+      val fetched = bucket.fetchWithSiblings(key).await
+
+      fetched should beNone
     }
   }
 }

--- a/src/test/scala/com/scalapenos/riak/RiakClientSpec.scala
+++ b/src/test/scala/com/scalapenos/riak/RiakClientSpec.scala
@@ -23,5 +23,4 @@ class RiakClientSpec extends RiakClientSpecification {
       client.ping.await should beTrue
     }
   }
-
 }

--- a/src/test/scala/com/scalapenos/riak/RiakGzipSpec.scala
+++ b/src/test/scala/com/scalapenos/riak/RiakGzipSpec.scala
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2012-2013 Age Mooij (http://scalapenos.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.scalapenos.riak
+
+import java.util.UUID.randomUUID
+
+class RiakGzipSpec extends AkkaActorSystemSpecification {
+
+  // ============================================================================
+  // Test data
+  // ============================================================================
+
+  val key = "foo"
+  val expectedValue = "bar"
+
+  // ============================================================================
+  // Specifications
+  // ============================================================================
+
+  "Riak client with an optional compression support" should {
+    "be able to have 2 clients (with & without compression) working with the same bucket where allowed_siblings=true" in {
+
+      val compressionDisabledClient = createRiakClient(false)
+      val compressionEnabledClient = createRiakClient(true)
+
+      val bucketName = s"$baseBucketName-$randomUUID"
+
+      val bucket = compressionEnabledClient.bucket(bucketName, fixedConflictResolver)
+
+      // Enable siblings for this bucket
+      bucket.setAllowSiblings(true).await
+
+      // Check there is no initial data
+      val fetchBeforeStore = bucket.fetch(key)
+      fetchBeforeStore.await must beNone
+
+      // This creates 2 siblings in the Riak bucket
+      bucket.storeAndFetch(key, "initial_bar").await
+      // but the expected value should win as we use a "fixed" conflict resolver
+      bucket.storeAndFetch(key, expectedValue).await
+
+      // Try to fetch it with both clients (with and without compression)
+      checkFetch(compressionEnabledClient, bucketName, key, expectedValue, Some(fixedConflictResolver))
+      checkFetch(compressionDisabledClient, bucketName, key, expectedValue, Some(fixedConflictResolver))
+    }
+
+    "be able to have 2 clients (with & without compression) working with the same bucket where allowed_siblings=false" in {
+
+      val gzipDisabledClient = createRiakClient(false)
+      val gzipEnabledClient = createRiakClient(true)
+
+      val bucketName = s"$baseBucketName-$randomUUID"
+
+      val bucket = gzipEnabledClient.bucket(bucketName)
+
+      // Disable siblings for this bucket
+      bucket.setAllowSiblings(false).await
+
+      // Check there is no initial data
+      val fetchBeforeStore = bucket.fetch(key)
+      fetchBeforeStore.await must beNone
+
+      // Put the expected value in Riak
+      bucket.storeAndFetch(key, expectedValue).await
+
+      // Try to fetch it with both clients (with and without compression)
+      checkFetch(gzipEnabledClient, bucketName, key, expectedValue)
+      checkFetch(gzipDisabledClient, bucketName, key, expectedValue)
+    }
+  }
+
+  // ============================================================================
+  // Helpers
+  // ============================================================================
+
+  private def baseBucketName = "test-client-compression-support"
+
+  private val fixedConflictResolver = new RiakConflictsResolver {
+    // Resolves conflicts by always preferring the expected value
+    override def resolve(values: Set[RiakValue]): ConflictResolution =
+      ConflictResolution(
+        values.find(_.data == expectedValue).getOrElse(throw new Exception("No expected value in siblings")),
+        writeBack = false)
+  }
+
+  private def checkFetch(client: RiakClient,
+    bucketName: String,
+    key: String,
+    expectedValue: String,
+    conflictResolver: Option[RiakConflictsResolver] = None) = {
+    val bucket =
+      conflictResolver.map(resolver ⇒ client.bucket(bucketName, resolver)).getOrElse(client.bucket(bucketName))
+
+    val fetchAfterStore = bucket.fetch(key).await
+
+    fetchAfterStore must beSome[RiakValue]
+    fetchAfterStore.get.data must beEqualTo(expectedValue)
+  }
+}

--- a/src/test/scala/com/scalapenos/riak/TestUtils.scala
+++ b/src/test/scala/com/scalapenos/riak/TestUtils.scala
@@ -12,7 +12,6 @@ import org.specs2.time.NoTimeConversions
 
 trait AkkaActorSystemSpecification extends Specification with NoTimeConversions {
   implicit val system = ActorSystem("tests")
-  implicit val executor = system.dispatcher
 
   // manual pimped future stolen^H^Hborrowed from spray.util because a
   // spray.util._ import causes implicit resolution conflicts with the above implicit actor system

--- a/src/test/scala/com/scalapenos/riak/TestUtils.scala
+++ b/src/test/scala/com/scalapenos/riak/TestUtils.scala
@@ -44,6 +44,19 @@ trait AkkaActorSystemSpecification extends Specification with NoTimeConversions 
   protected def decorateWith(fs: ⇒ Fragments)(text: String, block: ⇒ Unit) = {
     Seq(Br(), Br(), Text(text), Step(block)) ++: fs.middle :+ Backtab(1)
   }
+
+  protected def createRiakClient(enableCompression: Boolean) = {
+    val config = ConfigFactory.parseString(
+      s"""
+         |{
+         | riak {
+         |   enable-http-compression = $enableCompression
+         | }
+         |}
+      """.stripMargin)
+
+    RiakClient(createActorSystem(Some(config)))
+  }
 }
 
 abstract class RiakClientSpecification extends AkkaActorSystemSpecification with Before {
@@ -66,19 +79,6 @@ abstract class RiakClientSpecification extends AkkaActorSystemSpecification with
   }
 
   override def map(fs: ⇒ Fragments) = super.map(specsWithParametrizedCompression(fs))
-
-  private def createRiakClient(enableCompression: Boolean) = {
-    val config = ConfigFactory.parseString(
-      s"""
-         |{
-         | riak {
-         |   enable-http-compression = $enableCompression
-         | }
-         |}
-      """.stripMargin)
-
-    RiakClient(createActorSystem(Some(config)))
-  }
 }
 
 trait RandomKeySupport {

--- a/src/test/scala/com/scalapenos/riak/TestUtils.scala
+++ b/src/test/scala/com/scalapenos/riak/TestUtils.scala
@@ -49,6 +49,19 @@ trait RiakClientSpecification extends AkkaActorSystemSpecification with Before {
   }
 
   skipAllUnless(RiakClient(defaultSystem).ping.await)
+
+  protected def createRiakClient(enableCompression: Boolean) = {
+    val config = ConfigFactory.parseString(
+      s"""
+         |{
+         | riak {
+         |   enable-http-compression = $enableCompression
+         | }
+         |}
+      """.stripMargin)
+
+    RiakClient(createActorSystem(Some(config)))
+  }
 }
 
 trait RandomKeySupport {
@@ -60,5 +73,5 @@ trait RandomKeySupport {
 trait RandomBucketSupport {
   self: RiakClientSpecification with RandomKeySupport ⇒
 
-  def randomBucket = client.bucket("riak-bucket-tests-" + randomKey)
+  def randomBucket(implicit client: RiakClient) = client.bucket("riak-bucket-tests-" + randomKey)
 }

--- a/src/test/scala/com/scalapenos/riak/TestUtils.scala
+++ b/src/test/scala/com/scalapenos/riak/TestUtils.scala
@@ -1,17 +1,22 @@
 package com.scalapenos.riak
 
-import org.specs2.mutable._
+import java.util.UUID.randomUUID
+import java.util.concurrent.ConcurrentHashMap
 
 import scala.concurrent.Future
+import scala.collection.JavaConversions._
+
 import akka.actor._
 import akka.testkit._
+import com.typesafe.config.{ Config, ConfigFactory }
 
+import org.specs2.mutable._
 import org.specs2.execute.{ Failure, FailureException }
 import org.specs2.specification.{ Fragments, Step }
 import org.specs2.time.NoTimeConversions
 
 trait AkkaActorSystemSpecification extends Specification with NoTimeConversions {
-  implicit val system = ActorSystem("tests")
+  implicit val defaultSystem = createActorSystem()
 
   // manual pimped future stolen^H^Hborrowed from spray.util because a
   // spray.util._ import causes implicit resolution conflicts with the above implicit actor system
@@ -19,18 +24,31 @@ trait AkkaActorSystemSpecification extends Specification with NoTimeConversions 
 
   def failTest(msg: String) = throw new FailureException(Failure(msg))
 
+  lazy val actorSystems: ConcurrentHashMap[String, ActorSystem] = new ConcurrentHashMap[String, ActorSystem]()
+
   /* Add a final step to the list of test fragments that shuts down the actor system. */
-  override def map(fs: ⇒ Fragments) = super.map(fs).add(Step(system.shutdown))
+  override def map(fs: ⇒ Fragments) =
+    super.map(fs).add(Step(actorSystems.values().foreach(TestKit.shutdownActorSystem(_))))
+
+  protected def createActorSystem(customConfig: Option[Config] = None): ActorSystem = {
+    val systemName = s"tests-${randomUUID()}"
+    val system = customConfig match {
+      case Some(config) ⇒ ActorSystem(systemName, config)
+      case None         ⇒ ActorSystem(systemName)
+    }
+    actorSystems.put(systemName, system)
+    system
+  }
 }
 
 trait RiakClientSpecification extends AkkaActorSystemSpecification with Before {
   var client: RiakClient = _
 
   def before {
-    client = RiakClient(system)
+    client = RiakClient(defaultSystem)
   }
 
-  skipAllUnless(RiakClient(system).ping.await)
+  skipAllUnless(RiakClient(defaultSystem).ping.await)
 }
 
 trait RandomKeySupport {

--- a/src/test/scala/com/scalapenos/riak/UnsafeBucketOperationsSpec.scala
+++ b/src/test/scala/com/scalapenos/riak/UnsafeBucketOperationsSpec.scala
@@ -47,5 +47,4 @@ class UnsafeBucketOperationsSpec extends RiakClientSpecification with RandomKeyS
       allKeys.keys should be(Nil)
     }
   }
-
 }

--- a/src/test/scala/com/scalapenos/riak/UnsafeBucketOperationsSpec.scala
+++ b/src/test/scala/com/scalapenos/riak/UnsafeBucketOperationsSpec.scala
@@ -17,6 +17,8 @@
 package com.scalapenos.riak
 
 class UnsafeBucketOperationsSpec extends RiakClientSpecification with RandomKeySupport with RandomBucketSupport {
+  implicit val defaultClient = client
+
   def randomUnsafeBucketOperations = randomBucket.unsafe
 
   "UnsafeBucketOperations" should {

--- a/src/test/scala/com/scalapenos/riak/UnsafeBucketOperationsSpec.scala
+++ b/src/test/scala/com/scalapenos/riak/UnsafeBucketOperationsSpec.scala
@@ -17,9 +17,8 @@
 package com.scalapenos.riak
 
 class UnsafeBucketOperationsSpec extends RiakClientSpecification with RandomKeySupport with RandomBucketSupport {
-  implicit val defaultClient = client
 
-  def randomUnsafeBucketOperations = randomBucket.unsafe
+  def randomUnsafeBucketOperations = randomBucket(client).unsafe
 
   "UnsafeBucketOperations" should {
     "list all keys" in {

--- a/src/test/scala/com/scalapenos/riak/UnsafeBucketOperationsSpec.scala
+++ b/src/test/scala/com/scalapenos/riak/UnsafeBucketOperationsSpec.scala
@@ -26,13 +26,13 @@ class UnsafeBucketOperationsSpec extends RiakClientSpecification with RandomKeyS
       val numberOfKeys = 5
       val keys = (1 to numberOfKeys).map(_ ⇒ randomKey)
 
-      keys.map { key ⇒
+      keys.foreach { key ⇒
         unsafeBucketOperations.store(key, "value").await
       }
 
       val allKeys = unsafeBucketOperations.allKeys().await
 
-      keys.map { key ⇒
+      keys.foreach { key ⇒
         unsafeBucketOperations.delete(key).await
       }
 


### PR DESCRIPTION
## Goal

Gzip compression allows to greatly reduce the amount of traffic flowing from/to Riak clients to/from the database. It's especially helpful when there are conflicting values ("siblings") in Riak: in most cases, they are not that much different, so we can benefit from the standard data deduplication-based compression algorithms (such as Gzip). 
Quick measurements demonstrated that the payload can be reduced 8-10 times with gzipping enabled.

**UPDATE**: Requests payload compression has been reverted and put out-of-the-scope for now.
This is due to a number of known (by now) _issues_ like #41, #42, #43...
Also `store object` requests compression makes data stored this way in Riak incompatible with the old Riak Scala Client version (old clients won't be able to read it from Riak as it will respond with compressed responses by default, even if `Accept-Encoding` header has not been specified... see #42 in particular for details).

## Changes

This PR introduces a toggleable gzip compression (via a flag in the `reference.conf`) for requests' and responses' payloads.
Riak multipart responses (i.e. for 'siblings' cases) are also handled properly.

**UPDATE**: requests compression is put out-of-the-scope.

### Caveats

The only place where it didn't work out-of-the-box is `http PUT /bucket/<name>/props` endpoint. For some reason, this endpoint doesn't handle gzipped payload properly.
Because of that, compression has been disabled for requests targeting this endpoint.

**UPDATE**: this is not an issue anymore as requests compression is disabled altogether.